### PR TITLE
style: Increase color-preview size and update tab styles

### DIFF
--- a/css/special.css
+++ b/css/special.css
@@ -21,11 +21,10 @@ aside {
 }
 
 .color-preview {
-	width: 1rem;
-	height: 1rem;
-	border-radius: var(--border-radius-circle);
-	outline: 1px solid var(--c-border);
-	outline-offset: 2px;
+	width: 2rem;
+	height: 2rem;
+	border-radius: 3px;
+	border: 1px solid rgba(0, 0, 0, 0.4);
 }
 
 #paletteResults {
@@ -50,4 +49,19 @@ aside {
 	padding: 0;
 	margin: 0;
 	align-items: center;
+}
+
+.tab {
+	cursor: pointer;
+	padding: 10px;
+	border: 1px solid #ccc;
+	display: inline-block;
+	background-color: #f1f1f1;
+}
+.active-tab {
+	background-color: white;
+	border-bottom: none;
+}
+form {
+	margin-top: 20px;
 }


### PR DESCRIPTION
Modified the size of the color-preview element to 2rem width and height with a
border-radius of 3px. Updated tab styles with a border, background color, and
padding for a better user experience. Added new form margin for better spacing.